### PR TITLE
Adiciona endpoint para Provincias

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node -r tsconfig-paths/register src/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^6.10.14",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/got": "^9.6.11",
     "axios": "^0.19.2",
     "cheerio": "^1.0.0-rc.3",
+    "class-validator": "^0.12.2",
     "dotenv": "^8.2.0",
     "got": "^11.1.4",
     "mongoose": "^5.9.14",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,10 +3,16 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
 import { NifModule } from './nif/nif.module';
+import { ProvincesModule } from './provinces/provinces.module';
 import { SearchModule } from './search/search.module';
 
 @Module({
-  imports: [DatabaseModule, NifModule, SearchModule],
+  imports: [
+    DatabaseModule,
+    NifModule,
+    SearchModule,
+    ProvincesModule
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/database/seeders/provinces/data.ts
+++ b/src/database/seeders/provinces/data.ts
@@ -1,0 +1,348 @@
+import { CreateProvinceDto } from "../../../provinces/dtos/create-province.dto";
+
+export const data: CreateProvinceDto [] = [
+    {
+        name: "Bengo",
+        foundedAt: "1980-04-26",
+        capital: "Caxito",
+        area: "31.371 km²",
+        phonePrefix: "034",
+        website: "https://www.bengo.gov.ao",
+        counties: [
+            "Ambriz",
+            "Bula Atumba",
+            "Dande",
+            "Dembos",
+            "Nambuangongo",
+            "Pango Aluquém"
+        ]
+    },
+    {
+        name: "Benguela",
+        foundedAt: "1617",
+        capital: "Benguela",
+        area: "39.827 km²",
+        phonePrefix: "+244",
+        website: "https://www.benguela.gov.ao",
+        counties: [
+            "Balombo",
+            "Baía Farta",
+            "Benguela",
+            "Bocoio",
+            "Caimbambo",
+            "Catumbela",
+            "Chongorói",
+            "Cubal",
+            "Ganda",
+            "Lobito"
+        ]
+    },
+    {
+        name: "Bié",
+        foundedAt: "1922-05-01",
+        capital: "Cuíto",
+        area: "70.314 km²",
+        phonePrefix: "+244",
+        website: "https://www.bie.gov.ao",
+        counties: [
+            "Andulo",
+            "Camacupa",
+            "Catabola",
+            "Chinguar",
+            "Chitembo",
+            "Cuemba",
+            "Cunhinga",
+            "Cuíto",
+            "Nharea"
+        ]
+    },
+    {
+        name: "Cabinda",
+        foundedAt: "1919-02-28",
+        capital: "Cabinda",
+        area: "7.283 km²",
+        phonePrefix: "+244",
+        website: "https://www.cabinda.gov.ao",
+        counties: [
+            "Belize",
+            "Buco-Zau",
+            "Cabinda",
+            "Cacongo"
+        ]
+    },
+    {
+        name: "Cuando Cubango",
+        foundedAt: "1961-10-21",
+        capital: "Menongue",
+        area: "199.049 km²",
+        phonePrefix: "049",
+        website: "https://www.cuandocubango.gov.ao",
+        counties: [
+            "Calai",
+            "Cuangar",
+            "Cuchi",
+            "Cuito Cuanavale",
+            "Dirico",
+            "Mavinga",
+            "Menongue",
+            "Nancova",
+            "Rivungo"
+        ]
+    },
+    {
+        name: "Cuanza Norte",
+        foundedAt: "1914-08-15",
+        capital: "Ndalatando",
+        area: "24.110 km²",
+        phonePrefix: "035",
+        website: "https://www.cuanzanorte.gov.ao",
+        counties: [
+            "Ambaca",
+            "Banga",
+            "Bolongongo",
+            "Cambambe",
+            "Cazengo",
+            "Golungo Alto",
+            "Gonguembo",
+            "Lucala",
+            "Quiculungo",
+            "Samba Caju"
+        ]
+    },
+    {
+        name: "Cuanza Sul",
+        foundedAt: "1917-09-15",
+        capital: "Sumbe",
+        area: "55.660 km²",
+        phonePrefix: "+244",
+        website: "https://www.cuanzasul.gov.ao",
+        counties: [
+            "Amboim",
+            "Cassongue",
+            "Cela",
+            "Conda",
+            "Ebo",
+            "Libolo",
+            "Mussende",
+            "Porto Amboim",
+            "Quibala",
+            "Quilenda",
+            "Seles",
+            "Sumbe"
+        ]
+    },
+    {
+        name: "Cunene",
+        foundedAt: "1970-07-10",
+        capital: "Ondjiva",
+        area: "78.342 km²",
+        phonePrefix: "035",
+        website: "https://www.cunene.gov.ao",
+        counties: [
+            "Cahama",
+            "Cuanhama",
+            "Curoca",
+            "Cuvelai",
+            "Namacunde",
+            "Ombadja"
+        ]
+    },
+    {
+        name: "Huambo",
+        foundedAt: "1912-09-21",
+        capital: "Huambo",
+        area: "35.771 km²",
+        phonePrefix: "+244",
+        website: "https://www.huambo.gov.ao",
+        counties: [
+            "Bailundo",
+            "Cachiungo",
+            "Caála",
+            "Ecunha",
+            "Huambo",
+            "Londuimbali",
+            "Longonjo",
+            "Mungo",
+            "Chicala-Choloanga",
+            "Chinjenje",
+            "Ucuma"
+        ]
+    },
+    {
+        name: "Huíla",
+        foundedAt: "1901-09-02",
+        capital: "Lubango",
+        area: "79.022 km²",
+        phonePrefix: "+244",
+        website: "https://www.huila.gov.ao",
+        counties: [
+            "Caconda",
+            "Cacula",
+            "Caluquembe",
+            "Chiange",
+            "Chibia",
+            "Chicomba",
+            "Chipindo",
+            "Cuvango",
+            "Humpata",
+            "Jamba",
+            "Lubango",
+            "Matala",
+            "Quilengues",
+            "Quipungo"
+        ]
+    },
+    {
+        name: "Luanda",
+        foundedAt: "1576-01-01",
+        capital: "Luanda",
+        area: "18.826 km²",
+        phonePrefix: "222",
+        website: "https://www.luanda.gov.ao",
+        counties: [
+            "Belas",
+            "Cacuaco",
+            "Cazenga",
+            "Ícolo e Bengo",
+            "Luanda",
+            "Quilamba Quiaxi",
+            "Quissama",
+            "Talatona",
+            "Viana"
+        ]
+    },
+    {
+        name: "Lunda Norte",
+        foundedAt: "1978-07-04",
+        capital: "Dundo",
+        area: "103.760 km²",
+        phonePrefix: "+244",
+        website: "https://www.lundanorte.gov.ao",
+        counties: [
+            "Cambulo",
+            "Capenda-Camulemba",
+            "Caungula",
+            "Chitato",
+            "Cuango",
+            "Cuílo",
+            "Lóvua",
+            "Lubalo",
+            "Lucapa",
+            "Xá-Muteba"
+        ]
+    },
+    {
+        name: "Lunda Sul",
+        foundedAt: "1895-07-13",
+        capital: "Saurimo",
+        area: "77.636 km²",
+        phonePrefix: "+244",
+        website: "https://www.lundasul.gov.ao",
+        counties: [
+            "Cacolo",
+            "Dala",
+            "Muconda",
+            "Saurimo"
+        ]
+    },
+    {
+        name: "Malanje",
+        foundedAt: "1921",
+        capital: "Malanje",
+        area: "98.302 km²",
+        phonePrefix: "+244",
+        website: "https://www.malanje.gov.ao",
+        counties: [
+            "Cacuso",
+            "Calandula",
+            "Cambundi-Catembo",
+            "Cangandala",
+            "Caombo",
+            "Cuaba Nzoji",
+            "Cunda-Dia-Baze",
+            "Luquembo",
+            "Malanje",
+            "Marimba",
+            "Massango",
+            "Mucari",
+            "Quela",
+            "Quirima"
+        ]
+    },
+    {
+        name: "Moxico",
+        foundedAt: "1917-09-15",
+        capital: "Luena",
+        area: "223.023 km²",
+        phonePrefix: "+244",
+        website: "https://www.moxico.gov.ao",
+        counties: [
+            "Alto Zambeze",
+            "Bundas",
+            "Camanongue",
+            "Léua",
+            "Luau",
+            "Luacano",
+            "Luchazes",
+            "Cameia",
+            "Moxico"
+        ]
+    },
+    {
+        name: "Namibe",
+        foundedAt: "1849-04-19",
+        capital: "Moçâmedes",
+        area: "57.091 km²",
+        phonePrefix: "+244",
+        website: "https://www.namibe.gov.ao",
+        counties: [
+            "Bibala",
+            "Camucuio",
+            "Moçâmedes",
+            "Tômbua",
+            "Virei"
+        ]
+    },
+    {
+        name: "Uíge",
+        foundedAt: "1887-05-31",
+        capital: "Uíge",
+        area: "58.698 km²",
+        phonePrefix: "+244",
+        website: "https://www.uige.gov.ao",
+        counties: [
+            "Alto Cauale",
+            "Ambuíla",
+            "Bembe",
+            "Buengas",
+            "Bungo",
+            "Damba",
+            "Milunga",
+            "Mucaba",
+            "Negage",
+            "Puri",
+            "Quimbele",
+            "Quitexe",
+            "Sanza Pombo",
+            "Songo",
+            "Uíge",
+            "Zombo"
+        ]
+    },
+    {
+        name: "Zaire",
+        foundedAt: "1961-04-01",
+        capital: "Mbanza Congo",
+        area: "40.138 km²",
+        phonePrefix: "+232",
+        website: "https://www.zaire.gov.ao",
+        counties: [
+            "Cuimba",
+            "Mabanza Congo",
+            "Nóqui",
+            "Nezeto",
+            "Soio",
+            "Tomboco"
+        ]
+    }
+]

--- a/src/database/seeders/seeder.module.ts
+++ b/src/database/seeders/seeder.module.ts
@@ -1,0 +1,15 @@
+require('dotenv').config()
+import { Module, Logger } from "@nestjs/common";
+import { ProvincesModule } from "src/provinces/provinces.module";
+import { Seeder } from "./seeder";
+import { ProvincesService } from "src/provinces/provinces.service";
+import { DatabaseModule } from "../database.module";
+
+@Module({
+  imports: [
+    DatabaseModule,
+    ProvincesModule
+  ],
+  providers: [Logger, Seeder, ProvincesService]
+})
+export class SeederModule {}

--- a/src/database/seeders/seeder.ts
+++ b/src/database/seeders/seeder.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ProvincesService } from "src/provinces/provinces.service";
+import { data as provincesSeed } from "./provinces/data";
+
+@Injectable()
+export class Seeder {
+  constructor(
+    private readonly logger: Logger,
+    private readonly provinceService: ProvincesService
+  ) {}
+
+  async seed() {
+    this.logger.debug("Seeding...");
+
+    // All the seeds to be processed
+    await this.seedProvinces();
+    this.logger.debug("Provinces seed is finished! :)");
+  }
+
+  private async seedProvinces() {
+    let isAlreadySeeded = false;
+
+    provincesSeed.forEach(async province => {
+      try {
+        if (!!(await this.provinceService.findByName(province.name))) {
+          isAlreadySeeded = true;
+
+          this.logger.debug(`Province ${province.name} already seeded!`);
+        }
+      } catch(error) {
+        this.logger.error('[SEEDER]: Error while looking for seeded province on the database.');
+      }
+      
+      if (isAlreadySeeded === false) {
+        try {
+          await this.provinceService.create(province);
+        } catch (error) {
+          this.logger.error('[SEEDER]: Error while trying to seed the database.');
+        }
+      }
+    });
+
+    return isAlreadySeeded;
+  }
+}

--- a/src/provinces/dtos/create-province.dto.ts
+++ b/src/provinces/dtos/create-province.dto.ts
@@ -1,0 +1,24 @@
+import { IsArray, IsDate, IsFQDN, IsString } from 'class-validator';
+
+export class CreateProvinceDto {
+    @IsString()
+    readonly name: string;
+    
+    @IsString()
+    readonly capital: string;
+    
+    @IsDate()
+    readonly foundedAt: Date;
+
+    @IsString()
+    readonly area: string;
+
+    @IsString()
+    readonly phonePrefix: string;
+
+    @IsFQDN()
+    readonly website: string;
+
+    @IsArray()
+    readonly counties: string[];
+}

--- a/src/provinces/dtos/create-province.dto.ts
+++ b/src/provinces/dtos/create-province.dto.ts
@@ -8,7 +8,7 @@ export class CreateProvinceDto {
     readonly capital: string;
     
     @IsDate()
-    readonly foundedAt: Date;
+    readonly foundedAt: string;
 
     @IsString()
     readonly area: string;

--- a/src/provinces/provinces.controller.ts
+++ b/src/provinces/provinces.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, HttpException, InternalServerErrorException, BadRequestException } from '@nestjs/common';
 import { ProvincesService } from './provinces.service';
 import { CreateProvinceDto } from './dtos/create-province.dto';
 
@@ -14,5 +14,13 @@ export class ProvincesController {
     @Get()
     async findAll() {
         return await this.provincesService.findAll();
+    }
+
+    @Get(':id')
+    async findOne(@Param('id') id: string) {
+        if (typeof id !== 'string')
+            throw new BadRequestException('Por favor insira um ID válido.')
+
+        return await this.provincesService.findById(id);
     }
 }

--- a/src/provinces/provinces.controller.ts
+++ b/src/provinces/provinces.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { ProvincesService } from './provinces.service';
+import { CreateProvinceDto } from './dtos/create-province.dto';
+
+@Controller('provinces')
+export class ProvincesController {
+    constructor(private readonly provincesService: ProvincesService) {}
+
+    @Post('insert-many')
+    async insertMany(@Body() createProvinceDto: CreateProvinceDto []) {
+        return await this.provincesService.insertMany(createProvinceDto);
+    }
+
+    @Get()
+    async findAll() {
+        return await this.provincesService.findAll();
+    }
+}

--- a/src/provinces/provinces.controller.ts
+++ b/src/provinces/provinces.controller.ts
@@ -6,11 +6,6 @@ import { CreateProvinceDto } from './dtos/create-province.dto';
 export class ProvincesController {
     constructor(private readonly provincesService: ProvincesService) {}
 
-    @Post('insert-many')
-    async insertMany(@Body() createProvinceDto: CreateProvinceDto []) {
-        return await this.provincesService.insertMany(createProvinceDto);
-    }
-
     @Get()
     async findAll() {
         return await this.provincesService.findAll();

--- a/src/provinces/provinces.module.ts
+++ b/src/provinces/provinces.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Province, ProvinceSchema } from './schemas/province.schema';
+import { ProvincesService } from './provinces.service';
 
 @Module({
     imports: [
@@ -10,6 +11,7 @@ import { Province, ProvinceSchema } from './schemas/province.schema';
                 schema: ProvinceSchema 
             }
         ])
-    ]
+    ],
+    providers: [ProvincesService]
 })
 export class ProvincesModule {}

--- a/src/provinces/provinces.module.ts
+++ b/src/provinces/provinces.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class ProvincesModule {}

--- a/src/provinces/provinces.module.ts
+++ b/src/provinces/provinces.module.ts
@@ -14,6 +14,7 @@ import { ProvincesController } from './provinces.controller';
         ])
     ],
     providers: [ProvincesService],
-    controllers: [ProvincesController]
+    controllers: [ProvincesController],
+    exports: [ProvincesService, MongooseModule]
 })
 export class ProvincesModule {}

--- a/src/provinces/provinces.module.ts
+++ b/src/provinces/provinces.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Province, ProvinceSchema } from './schemas/province.schema';
 import { ProvincesService } from './provinces.service';
+import { ProvincesController } from './provinces.controller';
 
 @Module({
     imports: [
@@ -12,6 +13,7 @@ import { ProvincesService } from './provinces.service';
             }
         ])
     ],
-    providers: [ProvincesService]
+    providers: [ProvincesService],
+    controllers: [ProvincesController]
 })
 export class ProvincesModule {}

--- a/src/provinces/provinces.module.ts
+++ b/src/provinces/provinces.module.ts
@@ -1,4 +1,15 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Province, ProvinceSchema } from './schemas/province.schema';
 
-@Module({})
+@Module({
+    imports: [
+        MongooseModule.forFeature([
+            {
+                name: Province.name,
+                schema: ProvinceSchema 
+            }
+        ])
+    ]
+})
 export class ProvincesModule {}

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ProvincesService {}

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Province } from './schemas/province.schema';
 import { Model } from 'mongoose';
@@ -15,9 +15,20 @@ export class ProvincesService {
         .exec();
     }
 
-    async insertMany(data: CreateProvinceDto []) {
+    async insertMany(data: CreateProvinceDto []): Promise<CreateProvinceDto[]> {
         return await this.provinceModel
         
         .insertMany(data);
+    }
+
+    async findById(_id: string): Promise<CreateProvinceDto> {
+        const province = await this.provinceModel.findOne({ _id });
+
+        if (!province) {
+            console.log(province);
+            throw new NotFoundException('A província que tentou encontrar não existe');
+        }
+
+        return province;
     }
 }

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -14,4 +14,10 @@ export class ProvincesService {
         .find()
         .exec();
     }
+
+    async insertMany(data: CreateProvinceDto []) {
+        return await this.provinceModel
+        
+        .insertMany(data);
+    }
 }

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -1,12 +1,23 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Province } from './schemas/province.schema';
 import { Model } from 'mongoose';
 import { CreateProvinceDto } from './dtos/create-province.dto';
+import { Province } from './schemas/province.schema';
 
 @Injectable()
 export class ProvincesService {
     constructor(@InjectModel(Province.name) private provinceModel: Model<Province>) {}
+
+    async create(province: CreateProvinceDto): Promise<CreateProvinceDto> {
+        const { name } = province;
+        const exists = await this.provinceModel.findOne({ name });
+        
+        if (!!exists) {
+            throw new BadRequestException('Esta província já existe no banco de dados.');
+        }
+
+        return await this.provinceModel.create(province);
+    }
 
     async findAll(): Promise<Province[]> {
         return await this.provinceModel
@@ -15,8 +26,8 @@ export class ProvincesService {
         .exec();
     }
 
-    async findById(_id: string): Promise<CreateProvinceDto> {
-        const province = await this.provinceModel.findOne({ _id });
+    async findById(id: string): Promise<CreateProvinceDto> {
+        const province = await this.provinceModel.findById(id);
 
         if (!province) {
             console.log(province);

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -15,12 +15,6 @@ export class ProvincesService {
         .exec();
     }
 
-    async insertMany(data: CreateProvinceDto []): Promise<CreateProvinceDto[]> {
-        return await this.provinceModel
-        
-        .insertMany(data);
-    }
-
     async findById(_id: string): Promise<CreateProvinceDto> {
         const province = await this.provinceModel.findOne({ _id });
 

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -1,4 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Province } from './schemas/province.schema';
+import { Model } from 'mongoose';
+import { CreateProvinceDto } from './dtos/create-province.dto';
 
 @Injectable()
-export class ProvincesService {}
+export class ProvincesService {
+    constructor(@InjectModel(Province.name) private provinceModel: Model<Province>) {}
+
+    async findAll(): Promise<Province[]> {
+        return await this.provinceModel
+        
+        .find()
+        .exec();
+    }
+}

--- a/src/provinces/provinces.service.ts
+++ b/src/provinces/provinces.service.ts
@@ -36,4 +36,8 @@ export class ProvincesService {
 
         return province;
     }
+
+    async findByName(name: string) {
+        return await this.provinceModel.findOne({ name });
+    }
 }

--- a/src/provinces/schemas/province.schema.ts
+++ b/src/provinces/schemas/province.schema.ts
@@ -3,17 +3,17 @@ import { Document } from 'mongoose';
 
 @Schema()
 export class Province extends Document {
-    @Prop()
+    @Prop({ unique: true })
     name: string;
     
     @Prop()
     capital: string;
     
     @Prop()
-    foundedAt: Date;
+    foundedAt: string;
 
     @Prop()
-    area;
+    area: string;
 
     @Prop()
     phonePrefix: string;

--- a/src/provinces/schemas/province.schema.ts
+++ b/src/provinces/schemas/province.schema.ts
@@ -3,25 +3,25 @@ import { Document } from 'mongoose';
 
 @Schema()
 export class Province extends Document {
-    @Prop({ required: true })
+    @Prop()
     name: string;
     
-    @Prop({ required: true })
+    @Prop()
     capital: string;
     
-    @Prop({ required: true })
+    @Prop()
     foundedAt: Date;
 
-    @Prop({ required: true })
+    @Prop()
     area;
 
-    @Prop({ required: true })
+    @Prop()
     phonePrefix: string;
 
     @Prop()
     website: string;
 
-    @Prop({ required: true, type: [String] })
+    @Prop([String])
     counties: string[];
 }
 

--- a/src/provinces/schemas/province.schema.ts
+++ b/src/provinces/schemas/province.schema.ts
@@ -1,0 +1,28 @@
+import { Schema, Prop, SchemaFactory } from "@nestjs/mongoose";
+import { Document } from 'mongoose';
+
+@Schema()
+export class Province extends Document {
+    @Prop({ required: true })
+    name: string;
+    
+    @Prop({ required: true })
+    capital: string;
+    
+    @Prop({ required: true })
+    foundedAt: Date;
+
+    @Prop({ required: true })
+    area;
+
+    @Prop({ required: true })
+    phonePrefix: string;
+
+    @Prop()
+    website: string;
+
+    @Prop({ required: true, type: [String] })
+    counties: string[];
+}
+
+export const ProvinceSchema = SchemaFactory.createForClass(Province);

--- a/src/resources/database/seeds/provinces.json
+++ b/src/resources/database/seeds/provinces.json
@@ -1,0 +1,346 @@
+[
+    {
+        "name": "Bengo",
+        "foundedAt": "1980-04-26",
+        "capital": "Caxito",
+        "area": "31.371 km²",
+        "phonePrefix": "034",
+        "website": "https://www.bengo.gov.ao",
+        "counties": [
+            "Ambriz",
+            "Bula Atumba",
+            "Dande",
+            "Dembos",
+            "Nambuangongo",
+            "Pango Aluquém"
+        ]
+    },
+    {
+        "name": "Benguela",
+        "foundedAt": "1617",
+        "capital": "Benguela",
+        "area": "39.827 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.benguela.gov.ao",
+        "counties": [
+            "Balombo",
+            "Baía Farta",
+            "Benguela",
+            "Bocoio",
+            "Caimbambo",
+            "Catumbela",
+            "Chongorói",
+            "Cubal",
+            "Ganda",
+            "Lobito"
+        ]
+    },
+    {
+        "name": "Bié",
+        "foundedAt": "1922-05-01",
+        "capital": "Cuíto",
+        "area": "70.314 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.bie.gov.ao",
+        "counties": [
+            "Andulo",
+            "Camacupa",
+            "Catabola",
+            "Chinguar",
+            "Chitembo",
+            "Cuemba",
+            "Cunhinga",
+            "Cuíto",
+            "Nharea"
+        ]
+    },
+    {
+        "name": "Cabinda",
+        "foundedAt": "1919-02-28",
+        "capital": "Cabinda",
+        "area": "7.283 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.cabinda.gov.ao",
+        "counties": [
+            "Belize",
+            "Buco-Zau",
+            "Cabinda",
+            "Cacongo"
+        ]
+    },
+    {
+        "name": "Cuando Cubango",
+        "foundedAt": "1961-10-21",
+        "capital": "Menongue",
+        "area": "199.049 km²",
+        "phonePrefix": "049",
+        "website": "https://www.cuandocubango.gov.ao",
+        "counties": [
+            "Calai",
+            "Cuangar",
+            "Cuchi",
+            "Cuito Cuanavale",
+            "Dirico",
+            "Mavinga",
+            "Menongue",
+            "Nancova",
+            "Rivungo"
+        ]
+    },
+    {
+        "name": "Cuanza Norte",
+        "foundedAt": "1914-08-15",
+        "capital": "Ndalatando",
+        "area": "24.110 km²",
+        "phonePrefix": "035",
+        "website": "https://www.cuanzanorte.gov.ao",
+        "counties": [
+            "Ambaca",
+            "Banga",
+            "Bolongongo",
+            "Cambambe",
+            "Cazengo",
+            "Golungo Alto",
+            "Gonguembo",
+            "Lucala",
+            "Quiculungo",
+            "Samba Caju"
+        ]
+    },
+    {
+        "name": "Cuanza Sul",
+        "foundedAt": "1917-09-15",
+        "capital": "Sumbe",
+        "area": "55.660 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.cuanzasul.gov.ao",
+        "counties": [
+            "Amboim",
+            "Cassongue",
+            "Cela",
+            "Conda",
+            "Ebo",
+            "Libolo",
+            "Mussende",
+            "Porto Amboim",
+            "Quibala",
+            "Quilenda",
+            "Seles",
+            "Sumbe"
+        ]
+    },
+    {
+        "name": "Cunene",
+        "foundedAt": "1970-07-10",
+        "capital": "Ondjiva",
+        "area": "78.342 km²",
+        "phonePrefix": "035",
+        "website": "https://www.cunene.gov.ao",
+        "counties": [
+            "Cahama",
+            "Cuanhama",
+            "Curoca",
+            "Cuvelai",
+            "Namacunde",
+            "Ombadja"
+        ]
+    },
+    {
+        "name": "Huambo",
+        "foundedAt": "1912-09-21",
+        "capital": "Huambo",
+        "area": "35.771 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.huambo.gov.ao",
+        "counties": [
+            "Bailundo",
+            "Cachiungo",
+            "Caála",
+            "Ecunha",
+            "Huambo",
+            "Londuimbali",
+            "Longonjo",
+            "Mungo",
+            "Chicala-Choloanga",
+            "Chinjenje",
+            "Ucuma"
+        ]
+    },
+    {
+        "name": "Huíla",
+        "foundedAt": "1901-09-02",
+        "capital": "Lubango",
+        "area": "79.022 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.huila.gov.ao",
+        "counties": [
+            "Caconda",
+            "Cacula",
+            "Caluquembe",
+            "Chiange",
+            "Chibia",
+            "Chicomba",
+            "Chipindo",
+            "Cuvango",
+            "Humpata",
+            "Jamba",
+            "Lubango",
+            "Matala",
+            "Quilengues",
+            "Quipungo"
+        ]
+    },
+    {
+        "name": "Luanda",
+        "foundedAt": "1576-01-01",
+        "capital": "Luanda",
+        "area": "18.826 km²",
+        "phonePrefix": "222",
+        "website": "https://www.luanda.gov.ao",
+        "counties": [
+            "Belas",
+            "Cacuaco",
+            "Cazenga",
+            "Ícolo e Bengo",
+            "Luanda",
+            "Quilamba Quiaxi",
+            "Quissama",
+            "Talatona",
+            "Viana"
+        ]
+    },
+    {
+        "name": "Lunda Norte",
+        "foundedAt": "1978-07-04",
+        "capital": "Dundo",
+        "area": "103.760 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.lundanorte.gov.ao",
+        "counties": [
+            "Cambulo",
+            "Capenda-Camulemba",
+            "Caungula",
+            "Chitato",
+            "Cuango",
+            "Cuílo",
+            "Lóvua",
+            "Lubalo",
+            "Lucapa",
+            "Xá-Muteba"
+        ]
+    },
+    {
+        "name": "Lunda Sul",
+        "foundedAt": "1895-07-13",
+        "capital": "Saurimo",
+        "area": "77.636 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.lundasul.gov.ao",
+        "counties": [
+            "Cacolo",
+            "Dala",
+            "Muconda",
+            "Saurimo"
+        ]
+    },
+    {
+        "name": "Malanje",
+        "foundedAt": "1921",
+        "capital": "Malanje",
+        "area": "98.302 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.malanje.gov.ao",
+        "counties": [
+            "Cacuso",
+            "Calandula",
+            "Cambundi-Catembo",
+            "Cangandala",
+            "Caombo",
+            "Cuaba Nzoji",
+            "Cunda-Dia-Baze",
+            "Luquembo",
+            "Malanje",
+            "Marimba",
+            "Massango",
+            "Mucari",
+            "Quela",
+            "Quirima"
+        ]
+    },
+    {
+        "name": "Moxico",
+        "foundedAt": "1917-09-15",
+        "capital": "Luena",
+        "area": "223.023 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.moxico.gov.ao",
+        "counties": [
+            "Alto Zambeze",
+            "Bundas",
+            "Camanongue",
+            "Léua",
+            "Luau",
+            "Luacano",
+            "Luchazes",
+            "Cameia",
+            "Moxico"
+        ]
+    },
+    {
+        "name": "Namibe",
+        "foundedAt": "1849-04-19",
+        "capital": "Moçâmedes",
+        "area": "57.091 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.namibe.gov.ao",
+        "counties": [
+            "Bibala",
+            "Camucuio",
+            "Moçâmedes",
+            "Tômbua",
+            "Virei"
+        ]
+    },
+    {
+        "name": "Uíge",
+        "foundedAt": "1887-05-31",
+        "capital": "Uíge",
+        "area": "58.698 km²",
+        "phonePrefix": "+244",
+        "website": "https://www.uige.gov.ao",
+        "counties": [
+            "Alto Cauale",
+            "Ambuíla",
+            "Bembe",
+            "Buengas",
+            "Bungo",
+            "Damba",
+            "Milunga",
+            "Mucaba",
+            "Negage",
+            "Puri",
+            "Quimbele",
+            "Quitexe",
+            "Sanza Pombo",
+            "Songo",
+            "Uíge",
+            "Zombo"
+        ]
+    },
+    {
+        "name": "Zaire",
+        "foundedAt": "1961-04-01",
+        "capital": "Mbanza Congo",
+        "area": "40.138 km²",
+        "phonePrefix": "+232",
+        "website": "https://www.zaire.gov.ao",
+        "counties": [
+            "Cuimba",
+            "Mabanza Congo",
+            "Nóqui",
+            "Nezeto",
+            "Soio",
+            "Tomboco"
+        ]
+    }
+]

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,31 @@
+import { Logger } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { Seeder } from "./database/seeders/seeder";
+import { SeederModule } from "./database/seeders/seeder.module";
+
+async function bootstrap() {
+  NestFactory.createApplicationContext(SeederModule)
+  .then(ctx => {
+    const logger = ctx.get(Logger);
+    const seeder = ctx.get(Seeder);
+
+    seeder.seed()
+    .then(() => {
+      logger.debug("Seeding complete! :)");
+    })
+    .catch(error => {
+      logger.error("Seeding failed! :(");
+
+      throw error;
+    });
+
+    setTimeout(() => {
+      ctx.close();
+    }, 2000);
+  })
+  .catch(error => {
+    throw error;
+  });
+}
+
+bootstrap();

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/validator@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
+
 "@types/webpack-sources@*":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"
@@ -1901,6 +1906,16 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+class-validator@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.12.2.tgz#2ceb72f88873e9c714cf5f9c278cbc71f6f6c8ef"
+  integrity sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==
+  dependencies:
+    "@types/validator" "13.0.0"
+    google-libphonenumber "^3.2.8"
+    tslib ">=1.9.0"
+    validator "13.0.0"
 
 cli-color@2.0.0:
   version "2.0.0"
@@ -3360,6 +3375,11 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+google-libphonenumber@^3.2.8:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz#021a314652747d736a39e2e60dc670f0431425ad"
+  integrity sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==
 
 got@^11.1.4:
   version "11.1.4"
@@ -6893,6 +6913,11 @@ tslib@1.11.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
+tslib@>=1.9.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -7100,6 +7125,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Descrição

Adicionar suporte para obter informações sobre as províncias de Angola por meio do endpoint `https://buscador.co.ao/provinces`

## Reprodução

- [x] Pegar um json com essas informações e adicionar ao projecto.
- [x] Gerar uma interface para quem deseja fazer uma correção em alguma informação que possa estar incorreta.
- [x] Deixar acessível nos seguintes endpoints:
      - ` GET /provinces`  Retorna todas as províncias.
      -  `GET /provinces/:id` Retorna o aglomaredado de informações da província.
- [x] Adicionar Script para fazer o seed de províncias no banco usando o contexto da applicação.
```bash
$ npm run seed
```

## Testes

Não foi incluído nenhum teste para este PR.

## Notas

* Este PR adiciona uma nova dependência para validação de DTOs.

* As rotas para actualização das províncias não foram providenciadas. Não seria uma boa experiência deixar essas rotas públicas sendo que qualquer um poderia adicionar ou editar de qualquer jeito.

* O script para seed tem um delay de 2 segundos.

CC @acidiney 
Closes #3 